### PR TITLE
Deploy from databricks-dbutils-scala directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Publish to the Maven Central Repository
         run: mvn -DskipTests=true --batch-mode deploy
+        working-directory: ./databricks-dbutils-scala
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
## Changes
Release action currently fails because only the databricks-dbutils-scala directory should be deployed, not the example directories. This PR changes the release action to run within this subdirectory.

## Tests
<!-- How is this tested? -->

