### PR TITLE
Update main branch to stable release version 2.12

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Check formatting
-        run: mvn --errors --no-transfer-progress spotless:check -Pscala-2.13
+        run: mvn --errors --no-transfer-progress spotless:check -Pscala-2.12
 
   test:
     runs-on: ubuntu-latest
@@ -57,4 +57,4 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Run tests
-        run: mvn --errors --no-transfer-progress test -Pscala-2.13
+        run: mvn --errors --no-transfer-progress test -Pscala-2.12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
       fail-fast: false
       matrix:
         profile:
-#          - scala-2.12
-          - scala-2.13
+          - scala-2.12
+#          - scala-2.13
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/databricks-dbutils-scala/pom.xml
+++ b/databricks-dbutils-scala/pom.xml
@@ -4,17 +4,17 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.databricks</groupId>
-    <artifactId>databricks-dbutils-scala-parent_2.13</artifactId>
+    <artifactId>databricks-dbutils-scala-parent_2.12</artifactId>
     <version>0.1.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>databricks-dbutils-scala_2.13</artifactId>
+  <artifactId>databricks-dbutils-scala_2.12</artifactId>
   <dependencies>
     <!-- Scala Standard Library -->
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.13.5</version>
+      <version>2.12.10</version>
     </dependency>
     <!-- Nullable annotation -->
     <dependency>
@@ -46,12 +46,12 @@
     <!-- Scalatest test harness -->
     <dependency>
       <groupId>org.scalactic</groupId>
-      <artifactId>scalactic_2.13</artifactId>
+      <artifactId>scalactic_2.12</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.13</artifactId>
+      <artifactId>scalatest_2.12</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -76,11 +76,11 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>4.4.0</version>
         <configuration>
-          <scalaVersion>2.13.5</scalaVersion>
+          <scalaVersion>2.12.10</scalaVersion>
           <compilerPlugins>
             <compilerPlugin>
               <groupId>com.artima.supersafe</groupId>
-              <artifactId>supersafe_2.13.5</artifactId>
+              <artifactId>supersafe_2.12.10</artifactId>
               <version>1.1.12</version>
             </compilerPlugin>
           </compilerPlugins>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.databricks</groupId>
-    <artifactId>databricks-dbutils-scala-parent_2.13</artifactId>
+    <artifactId>databricks-dbutils-scala-parent_2.12</artifactId>
     <version>0.1.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
@@ -23,7 +23,7 @@
     </dependency>
     <dependency>
       <groupId>com.databricks</groupId>
-      <artifactId>databricks-dbutils-scala_2.13</artifactId>
+      <artifactId>databricks-dbutils-scala_2.12</artifactId>
       <version>0.1.4</version>
     </dependency>
   </dependencies>
@@ -34,7 +34,7 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>4.4.0</version>
         <configuration>
-          <scalaVersion>2.13.5</scalaVersion>
+          <scalaVersion>2.12.10</scalaVersion>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <!-- Group and artifact identifiers, versioning -->
   <groupId>com.databricks</groupId>
-  <artifactId>databricks-dbutils-scala-parent_2.13</artifactId>
+  <artifactId>databricks-dbutils-scala-parent_2.12</artifactId>
   <version>0.1.4</version>
   <packaging>pom</packaging>
   <name>DBUtils for Scala</name>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -4,11 +4,11 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.databricks</groupId>
-    <artifactId>databricks-dbutils-scala-parent_2.13</artifactId>
+    <artifactId>databricks-dbutils-scala-parent_2.12</artifactId>
     <version>0.1.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
-  <artifactId>release-2.13</artifactId>
+  <artifactId>release-2.12</artifactId>
   <name>Release Module</name>
   <description>Module purely for releasing using Nexus staging plugin</description>
   <build>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We have both 2.12 and 2.13 working releases on maven central. 

DBConnect only requires 2.12, however the main branch currently is based on 2.13. 

In future, we might need to do a patch release (in case an issue occurs) for that we should have main branch updated with 2.12 instead of 2.13.

## Tests
<!-- How is this tested? -->
NA
