### PR TITLE
Allow non primitive null values while getting a proxyInstance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
+++ b/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
@@ -50,6 +50,19 @@ private object ProxyDBUtilsImpl {
     threadLocal.get()
   }
 
+  def isParameterTypeCompatible(paramType: Class[_], arg: Any): Boolean = {
+    // Argument shouldn't be null and primitive
+    if (arg == null && paramType.isPrimitive) {
+      throw new NoSuchMethodException("Unexpected null argument for primitive type")
+    }
+
+    // Either arg is null but non primitive or arg's class is the same as paramType and or arg's class is a subtype of paramType, 
+    // or arg's class is a boxed type and paramType is the corresponding primitive type.
+    (arg == null && !paramType.isPrimitive) || 
+    (paramType.isAssignableFrom(arg.getClass)) || 
+    (paramType.isPrimitive && paramType.isAssignableFrom(toPrimitiveClass(arg.getClass)))
+  }
+
   def toPrimitiveClass(clazz: Class[_]): Class[_] = clazz match {
     case c if c == classOf[java.lang.Boolean]   => java.lang.Boolean.TYPE
     case c if c == classOf[java.lang.Byte]      => java.lang.Byte.TYPE
@@ -88,15 +101,7 @@ private object ProxyDBUtilsImpl {
           val backendMethod = backendInstance.getClass.getMethods
             .find { m =>
               m.getName == method.getName && m.getParameterTypes.length == convertedArgs.length &&
-              m.getParameterTypes.zip(convertedArgs).forall { case (paramType, arg) =>
-                // Argument shouldn't be null and primitive
-                if (arg == null && paramType.isPrimitive) {
-                  throw new NoSuchMethodException("Unexpected null argument for primitive type")
-                }
-                // Either arg is null but non primitive or arg's class is the same as paramType and , or arg's class is a subtype of paramType, or arg's
-                // class is a boxed type and paramType is the corresponding primitive type. For example:
-                (arg == null && !paramType.isPrimitive) || (paramType.isAssignableFrom(arg.getClass)) ||
-                (paramType.isPrimitive && paramType.isAssignableFrom(toPrimitiveClass(arg.getClass)))
+              m.getParameterTypes.zip(convertedArgs).forall { case (paramType, arg) => isParameterTypeCompatible(paramType, arg)
               }
             }
             .getOrElse {

--- a/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
+++ b/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
@@ -89,9 +89,13 @@ private object ProxyDBUtilsImpl {
             .find { m =>
               m.getName == method.getName && m.getParameterTypes.length == convertedArgs.length &&
               m.getParameterTypes.zip(convertedArgs).forall { case (paramType, arg) =>
-                // Either arg's class is the same as paramType, or arg's class is a subtype of paramType, or arg's
+                // Argument shouldn't be null and primitive
+                if(arg == null && paramType.isPrimitive){
+                  throw new NoSuchMethodException("Unexpected null argument for primitive type")
+                }
+                // Either arg is null but non primitive or arg's class is the same as paramType and , or arg's class is a subtype of paramType, or arg's
                 // class is a boxed type and paramType is the corresponding primitive type. For example:
-                paramType.isAssignableFrom(arg.getClass) ||
+                (arg == null && !paramType.isPrimitive) || (paramType.isAssignableFrom(arg.getClass)) ||
                 (paramType.isPrimitive && paramType.isAssignableFrom(toPrimitiveClass(arg.getClass)))
               }
             }

--- a/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
+++ b/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
@@ -101,7 +101,8 @@ private object ProxyDBUtilsImpl {
           val backendMethod = backendInstance.getClass.getMethods
             .find { m =>
               m.getName == method.getName && m.getParameterTypes.length == convertedArgs.length &&
-              m.getParameterTypes.zip(convertedArgs).forall { case (paramType, arg) => isParameterTypeCompatible(paramType, arg)
+              m.getParameterTypes.zip(convertedArgs).forall { case (paramType, arg) =>
+                isParameterTypeCompatible(paramType, arg)
               }
             }
             .getOrElse {

--- a/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
+++ b/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
@@ -90,7 +90,7 @@ private object ProxyDBUtilsImpl {
               m.getName == method.getName && m.getParameterTypes.length == convertedArgs.length &&
               m.getParameterTypes.zip(convertedArgs).forall { case (paramType, arg) =>
                 // Argument shouldn't be null and primitive
-                if(arg == null && paramType.isPrimitive){
+                if (arg == null && paramType.isPrimitive) {
                   throw new NoSuchMethodException("Unexpected null argument for primitive type")
                 }
                 // Either arg is null but non primitive or arg's class is the same as paramType and , or arg's class is a subtype of paramType, or arg's

--- a/databricks-dbutils-scala/src/test/scala/com/databricks/sdk/scala/dbutils/ProxyDbfsTest.scala
+++ b/databricks-dbutils-scala/src/test/scala/com/databricks/sdk/scala/dbutils/ProxyDbfsTest.scala
@@ -103,4 +103,26 @@ class ProxyDbfsTest extends AnyFlatSpec {
     assert(res === Seq(SecretScope("testScope")))
     verify(proxySecrets).listScopes()
   }
+
+  "isParameterTypeCompatible" should "return true for null argument and non-primitive parameter type" in {
+    val result = ProxyDBUtilsImpl.isParameterTypeCompatible(classOf[String], null)
+    assert(result == true)
+  }
+
+  "isParameterTypeCompatible" should "return true when argument matches parameter type exactly" in {
+    val result = ProxyDBUtilsImpl.isParameterTypeCompatible(classOf[String], "test")
+    assert(result == true)
+  }
+
+  "isParameterTypeCompatible" should "return false when argument is incompatible with parameter type" in {
+    val result = ProxyDBUtilsImpl.isParameterTypeCompatible(classOf[Int], "test")
+    assert(result == false)
+  }
+
+  "isParameterTypeCompatible" should "throw NoSuchMethodException with the correct message for null argument and primitive parameter type" in {
+    val exception = intercept[NoSuchMethodException] {
+      ProxyDBUtilsImpl.isParameterTypeCompatible(classOf[Int], null)
+    }
+    assert(exception.getMessage == "Unexpected null argument for primitive type")
+  }
 }


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Is a parameter is non-primitive but null then it should be allowed and we need to check for this before doing any operation on the said `arg` i.e. in this case it would be arg.getClass

## Tests
<!-- How is this tested? -->
WIP
