### PR TITLE
Fixed `SdkDbfsIntegrationTest`

### DIFF
--- a/databricks-dbutils-scala/src/test/scala/com/databricks/sdk/scala/dbutils/integration/SdkDbfsIntegrationTest.scala
+++ b/databricks-dbutils-scala/src/test/scala/com/databricks/sdk/scala/dbutils/integration/SdkDbfsIntegrationTest.scala
@@ -13,8 +13,7 @@ class SdkDbfsIntegrationTest extends VolumeIntegrationTestBase {
       dbutils.fs.put(testFilePath, testFile)
     }
 
-    e.getMessage should be(
-      "Invalid path: unsupported first path component: tmp")
+    e.getMessage should be("Invalid path: unsupported first path component: tmp")
   }
 
   // More tests to verify that we can't copy/move outside or across UC interface or delete outside of DBFS

--- a/databricks-dbutils-scala/src/test/scala/com/databricks/sdk/scala/dbutils/integration/SdkDbfsIntegrationTest.scala
+++ b/databricks-dbutils-scala/src/test/scala/com/databricks/sdk/scala/dbutils/integration/SdkDbfsIntegrationTest.scala
@@ -1,4 +1,5 @@
 package com.databricks.sdk.scala.dbutils.integration
+import com.databricks.sdk.core.DatabricksError
 
 class SdkDbfsIntegrationTest extends VolumeIntegrationTestBase {
   "When outside of DBR, FSUtils" should "not be able to upload outside of /Volumes" taggedAs Integration in {
@@ -8,12 +9,12 @@ class SdkDbfsIntegrationTest extends VolumeIntegrationTestBase {
     val testFilePath = s"/tmp/upload_and_download.txt"
     val testFile = "Hello, world!"
 
-    val e = intercept[IllegalArgumentException] {
+    val e = intercept[DatabricksError] {
       dbutils.fs.put(testFilePath, testFile)
     }
 
     e.getMessage should be(
-      "requirement failed: Cannot upload to paths outside of /Volumes outside of DBR: /tmp/upload_and_download.txt")
+      "Invalid path: unsupported first path component: tmp")
   }
 
   // More tests to verify that we can't copy/move outside or across UC interface or delete outside of DBFS


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
`mvn install -Dgpg.skip=true` is failing on main with:
```
20:06 [DEBUG] > PUT /api/2.0/fs/files//tmp/upload_and_download.txt
> <InputStream>
< 400 Bad Request
< {
<   "details" : [ {
<     "@type" : "type.googleapis.com/google.rpc.ErrorInfo",
<     "domain" : "filesystem.databricks.com",
<     "metadata" : {
<       "validation_error" : "unsupported first path component: tmp"
<     },
<     "reason" : "FILES_API_INVALID_PATH"
<   } ],
<   "error_code" : "BAD_REQUEST",
<   "message" : "Invalid path: unsupported first path component: tmp"
< }
- should not be able to upload outside of /Volumes *** FAILED ***
  Expected exception java.lang.IllegalArgumentException to be thrown, but com.databricks.sdk.core.DatabricksError was thrown (SdkDbfsIntegrationTest.scala:11)
```
It seems like we are catching the wrong exception, maybe there was a change in backend? (needs to be confirmed). The recent changes in the repository doesn't seem to be related to this error. 

Since the API call is made and an error is thrown when not using `/Volumes`, the purpose of the test remains the same. If /Volumes is used, then we get further that the schema wasn't provided: 
`"Invalid path: [Path is missing a schema name]"`

## Tests
<!-- How is this tested? -->
`mvn install -Dgpg.skip=true` passes over the change.
