### PR TITLE
Add getServiceCredentials to DBUtils.scala

### DIFF
--- a/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/DBUtils.scala
+++ b/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/DBUtils.scala
@@ -467,8 +467,8 @@ trait DatabricksCredentialUtils extends Serializable with WithHelpMethods {
   /**
    * Get an instance of cloud-specific Service Credentials Provider.
    *
-   * Return type is an Object because the actual type is cloud-specific
-   * (e.g. AWSCredentialsProvider on AWS, TokenCredential on Azure).
+   * Return type is an Object because the actual type is cloud-specific (e.g. AWSCredentialsProvider on AWS,
+   * TokenCredential on Azure).
    *
    * Example:
    * {{{


### PR DESCRIPTION
Adds getServiceCredentialsProvider to dbutils.credentials API.

It was added to the internal impl object for Scala SDK, but not to this project.

## Changes
<!-- Summary of your changes that are easy to understand -->

## Tests
<!-- How is this tested? -->

