### PR TITLE
[Internal] Update workflows actions cache version to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
 
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
We currently use v2 of actions cache in release workflow which is not supported and leads to failed release: 

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

We use v3 in other places
https://github.com/databricks/databricks-dbutils-scala/blob/main/.github/workflows/pr.yaml#L53


## Tests
<!-- How is this tested? -->
N/A 