### PR TITLE
[Internal] Skip publishing examples and define child project name

### DIFF
--- a/databricks-dbutils-scala/pom.xml
+++ b/databricks-dbutils-scala/pom.xml
@@ -9,6 +9,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>databricks-dbutils-scala_2.12</artifactId>
+  <name>DBUtils for Scala</name>
   <dependencies>
     <!-- Scala Standard Library -->
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -65,6 +65,9 @@
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <version>0.5.0</version>
+        <configuration>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
[1] Skip examples from being published as we don't have proper java docs for them and the plugin doesn't generate them.

> The plugin does not generate all of the prerequisites for a valid bundle, so you'll want to follow the documentation for building [Javadoc and sources .jar files](https://central.sonatype.org/publish/publish-maven/#javadoc-and-sources-attachments) and [GPG signature files](https://central.sonatype.org/publish/publish-maven/#gpg-signed-components).

Ref: https://central.sonatype.org/publish/publish-portal-maven/#skippublishing

Error:
> pkg:maven/com.databricks/databricks-dbutils-scala-examples@0.1.5:
Sources must be provided but not found in entries
Javadocs must be provided but not found in entries

[2] Add name to child pom as it is not inherited from parent (Not sure why this is happening now and not before on `nexus-staging-maven-plugin`). Error:
> pkg:maven/com.databricks/databricks-dbutils-scala_2.12@0.1.5:
> Project name is missing

## Tests
<!-- How is this tested? -->
While we have dry run of publishing, the errors during actual publishing can be resolved during the actual deployment. Currently we don't have a staging deployment infrastructure to test this. 