### PR TITLE
[Internal] Add support to publish DBUtils Scala without sources and javadoc

### DIFF
--- a/release/pom.xml
+++ b/release/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <artifactId>release-2.12</artifactId>
   <name>Release Module</name>
-  <description>Module purely for releasing using Maven central publising plugin</description>
+  <description>Module purely for release using maven central publising plugin</description>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Exclude the examples directly in release module. Ref: https://github.com/databricks/databricks-dbutils-scala/blob/main/examples/pom.xml#L63

Currently the release is failing with: 
> pkg:maven/com.databricks/databricks-dbutils-scala-examples@0.1.5:
Sources must be provided but not found in entries
Javadocs must be provided but not found in entries

## Tests
<!-- How is this tested? -->
It's difficult to test, we have dry run of release but the failure happens during publishing to maven central. 
