### PR TITLE
[Internal] Remove examples from parent pom and central-publishing-maven-plugin in examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -60,15 +60,6 @@
           -->
         </configuration>
       </plugin>
-      <!-- No need to release the example -->
-      <plugin>
-        <groupId>org.sonatype.central</groupId>
-        <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.5.0</version>
-        <configuration>
-          <skipPublishing>true</skipPublishing>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
   </developers>
   <modules>
     <module>databricks-dbutils-scala</module>
-    <module>examples</module>
     <module>release</module>
   </modules>
   <scm>


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand -->
Since we don't publish examples, we don't need this plugin. 

## Tests
<!-- How is this tested? -->
Existing CI tests
