### PR TITLE
[BUG] Adding Option string to CommandContextClass

### DIFF
--- a/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
+++ b/databricks-dbutils-scala/src/main/scala/com/databricks/sdk/scala/dbutils/ProxyDBUtilsImpl.scala
@@ -173,7 +173,7 @@ private object ProxyDBUtilsImpl {
       .getConstructor(
         classOf[Option[AnyRef]],
         classOf[Option[AnyRef]],
-        classOf[String],
+        classOf[Option[String]],
         classOf[Map[String, String]],
         classOf[Map[String, String]])
       .newInstance(


### PR DESCRIPTION
<!-- Summary of your changes that are easy to understand -->
This pull request is related to  issue #55 .
The variable commandContextClass which references the internal class com.databricks.backend.common.rpc.CommandContext, has a type mismatch in the constructor. The real constructor is com.databricks.sdk.scala.dbutils.CommandContext(scala.Option,scala.Option,scala.Option,scala.collection.immutable.Map,scala.collection.immutable.Map) but the defined one was 

val commandContextClass = Class.forName("com.databricks.backend.common.rpc.CommandContext")
commandContextClass
.getConstructor(
classOf[Option[AnyRef]],
classOf[Option[AnyRef]],
**classOf[String], //should be change to classOf[Option[String]]**
classOf[Map[String, String]],
classOf[Map[String, String]])
.newInstance(
rootRunIdOpt,
currentRunIdOpt,
commandContext.jobGroup,
commandContext.tags,
commandContext.extraContext)
.asInstanceOf[AnyRef]

So I modified to be classOf[Option[String] instead of classOf[String]

## Tests
<!-- How is this tested? -->
Running unit testing in local with successful result and also compiled the jar and tested in Databricks environment.

